### PR TITLE
update retryVendFromDifferentProvider condition

### DIFF
--- a/src/models/Transaction.model.ts
+++ b/src/models/Transaction.model.ts
@@ -12,7 +12,8 @@ import { NigerianDate } from "../utils/Date";
 export enum Status {
     COMPLETE = 'COMPLETE',
     PENDING = 'PENDING',
-    FAILED = 'FAILED'
+    FAILED = 'FAILED',
+    FLAGGED = 'FLAGGED'
 }
 
 export enum PaymentType {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -38,6 +38,7 @@ export const KAFKA_USERNAME = process.env.KAFKA_USERNAME as string;
 export const KAFKA_PASSWORD = process.env.KAFKA_PASSWORD as string;
 export const KAFKA_BROKER = process.env.KAFKA_BROKER as string;
 export const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY as string;
+export const MAX_REQUERY_PER_VENDOR = parseInt(process.env.MAX_REQUERY_PER_VENDOR as string, 10) 
 
 export const DISCO_LOGO = {
     abuja: "https://res.cloudinary.com/richiepersonaldev/image/upload/v1699947957/dpijlhj08ard76zao2uk.jpg",


### PR DESCRIPTION
Updated the condition to retry power purchase from a different vendor

- Retries from different vendors will be triggered only after the transaction fails
- Flag transaction after continuous requery from vendor above set limit